### PR TITLE
Fix wrong usage of feof

### DIFF
--- a/src/k3rmit.h
+++ b/src/k3rmit.h
@@ -34,7 +34,7 @@
 #define TERM_ATTR_DEFAULT "\x1b[39m"
 
 static GtkWidget* getTerm();
-static int parseSettings();
+static void parseSettings();
 static int configureTerm(GtkWidget* term);
 static int setTermFont(GtkWidget *term, int fontSize);
 static gboolean termOnChildExit(VteTerminal *term,


### PR DESCRIPTION
Hi,

The C function [feof](https://en.cppreference.com/w/c/io/feof) can only be used after at least one I/O operation and cannot be used immediately after `fopen`.

This is a [common mistake](https://stackoverflow.com/questions/5431941/why-is-while-feof-file-always-wrong) that I simply fixed by checking the result of `fgets` which is usually enough.

While here, since the function always return 0 and its result code is never tested I simply removed it and reduced indent level.